### PR TITLE
chore: add system-specific directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,6 +143,9 @@ Cloud_Sync/
 Remote_Cache/
 System Logs/*.log
 Work Logs/*.log
+Current Objective/
+Simulation/
+implementation/
 
 # Build and temporary files
 artifacts/


### PR DESCRIPTION
This PR updates the .gitignore file to include system-specific directories:

- Current Objective/
- Simulation/
- implementation/

These directories are specific to the local development environment and should not be tracked in version control.

This change helps keep the repository clean and prevents accidental commits of system-specific files.